### PR TITLE
Bugfix/ecpq 3508

### DIFF
--- a/src/lib/ProductExporter.ts
+++ b/src/lib/ProductExporter.ts
@@ -79,40 +79,37 @@ export class ProductExporter {
 
     private async retrieveProduct(conn: Connection, productList: Set<string>) {
         Util.showSpinner('products export');
+        
         let productDefinitions = await Queries.queryProduct(conn, productList);
+        this.checkTechIds(productDefinitions);
+
         let options = await Queries.queryProductOptions(conn, productList);
+        this.checkTechIds(options);
+
         let chargesIds = await Queries.queryProductChargesIds(conn, productList);
+        
         let productAttributes = await Queries.queryProductAttributes(conn, productList);
+        this.checkTechIds(productAttributes);
+
         let attributeValues = await Queries.queryProductAttributeValues(conn, productList);
+        this.checkTechIds(attributeValues);
+
         let attributeDefaultValues = await Queries.queryAttributeDefaultValues(conn, productList);
+        this.checkTechIds(attributeDefaultValues);
+
         let attributeValueDependencies = await Queries.queryAttributeValueDependencies(conn, productList);
+        this.checkTechIds(attributeValueDependencies);
+
         let attributeRules = await Queries.queryAttributeRules(conn, productList);
+        this.checkTechIds(attributeRules);
+
         let productRelationships = await Queries.queryProductRelationships(conn, productList);
-
-
-        const objectsToCheckTechId = [
-            ...productDefinitions,
-            ...options,
-            ...productAttributes, 
-            ...attributeValues, 
-            ...attributeDefaultValues,
-            ...attributeValueDependencies,
-            ...attributeRules,
-            ...productRelationships
-        ];
+        this.checkTechIds(productRelationships);
 
         let provisioningPlanAssings:any = {};
         if(this.isB2B){
-           provisioningPlanAssings = await Queries.queryProvisioningPlanAssigns(conn, productList);
-           objectsToCheckTechId.push(...provisioningPlanAssings);
-        }
-
-        const objectsMissingTechId = Util.getObjectsMissingTechId(objectsToCheckTechId);
-
-        if(objectsMissingTechId.length !== 0){
-            objectsMissingTechId.forEach((object) => {
-                Util.log(Util.OBJECT_MISSING_TECH_ID_ERROR + ': ' + object.Id);
-            });
+            provisioningPlanAssings = await Queries.queryProvisioningPlanAssigns(conn, productList);
+            this.checkTechIds(provisioningPlanAssings);
         }
        
         for(let productDefinition of productDefinitions){
@@ -284,23 +281,6 @@ export class ProductExporter {
         let stdPriceBookEntries = await Queries.queryStdPricebookEntries(conn, productList);
         let chargeElementPricebookEntries = await Queries.queryChargeElementPricebookEntries(conn, productList);
         let chargeElementStdPricebookEntries = await Queries.queryChargeElementStdPricebookEntries(conn, productList);
-        
-        
-
-        // let objectsMissingTechId = Util.getObjectsMissingTechId([
-        //     ...chargeElementPricebookEntries,
-        //     ...chargeElementStdPricebookEntries,
-        //     ...priceBooks, 
-        //     ...priceBookEntries, 
-        //     ...stdPriceBookEntries
-        // ]);
-
-        // if(objectsMissingTechId.length !== 0){
-        //     debugger;
-        //     objectsMissingTechId.forEach((object) => {
-        //         Util.log(Util.OBJECT_MISSING_TECH_ID_ERROR + ': ' + object.Id);
-        //     });
-        // }
 
         if(priceBooks){
         priceBooks.forEach(priceBook => {

--- a/src/lib/ProductExporter.ts
+++ b/src/lib/ProductExporter.ts
@@ -108,6 +108,18 @@ export class ProductExporter {
             provisioningPlanAssings = await Queries.queryProvisioningPlanAssigns(conn, productList);
             this.checkTechIds(provisioningPlanAssings);
         }
+
+        Util.removeIdFields([
+            ...productDefinitions,
+            ...options,
+            ...productAttributes,
+            ...attributeValues,
+            ...attributeDefaultValues,
+            ...attributeValueDependencies,
+            ...attributeRules,
+            ...productRelationships,
+            ...provisioningPlanAssings
+        ]);
        
         for(let productDefinition of productDefinitions){
            let product:any = {};
@@ -190,6 +202,9 @@ export class ProductExporter {
             Util.writeFile('/categories/' + category['Name'] +'_' +category['enxCPQ__TECH_External_Id__c']+ '.json', category);
         }
         let newParentCategories = await Queries.queryCategories(conn, parentCategoriesIds);
+        this.checkTechIds(newParentCategories);
+
+        Util.removeIdFields(newParentCategories);
 
         if(newParentCategories){
             this.retrieveCategoriesHelper(conn, newParentCategories);
@@ -199,6 +214,8 @@ export class ProductExporter {
     private async retrieveCategories(conn: Connection) {
         let categories = await Queries.queryCategories(conn, this.categoryIds);
         this.checkTechIds(categories);
+
+        Util.removeIdFields(categories);
         
         if(categories){
            await this.retrieveCategoriesHelper(conn, categories);
@@ -211,6 +228,11 @@ export class ProductExporter {
 
         let attributeValues = await Queries.queryAttributeValues(conn, this.attributeIds);
         this.checkTechIds(attributeValues);
+
+        Util.removeIdFields([
+            ...attributes,
+            ...attributeValues
+        ]);
 
         if(attributes){
             attributes.forEach(attribute => {
@@ -234,6 +256,11 @@ export class ProductExporter {
         let attributeSetAttributes = await Queries.queryAttributeSetAttributes(conn, this.attributeSetIds);
         this.checkTechIds(attributeSetAttributes);
 
+        Util.removeIdFields([
+            ...attributeSets,
+            ...attributeSetAttributes
+        ]);
+
         if (attributeSets){
         attributeSets.forEach(attributeSet => {
         
@@ -256,6 +283,11 @@ export class ProductExporter {
         let prvTaskAssignments = await Queries.queryProvisioningTaskAssignments(conn)
         this.checkTechIds(prvTaskAssignments);
 
+        Util.removeIdFields([
+            ...provisioningPlans,
+            ...prvTaskAssignments
+        ]);
+
         provisioningPlans.forEach(provisioningPlan=>{
         
             let provisioningPlanToSave:any = {};
@@ -274,6 +306,8 @@ export class ProductExporter {
         let provisioningTasks = await Queries.queryProvisioningTasks(conn);
         this.checkTechIds(provisioningTasks);
 
+        Util.removeIdFields(provisioningTasks);
+
         provisioningTasks.forEach(provisioningTask => {
             Util.writeFile('/provisioningTasks/' + Util.sanitizeFileName(provisioningTask['Name']) +'_' + provisioningTask['enxB2B__TECH_External_Id__c']+ '.json', provisioningTask);
         });
@@ -288,6 +322,8 @@ export class ProductExporter {
         let stdPriceBookEntries = await Queries.queryStdPricebookEntries(conn, productList);
         let chargeElementPricebookEntries = await Queries.queryChargeElementPricebookEntries(conn, productList);
         let chargeElementStdPricebookEntries = await Queries.queryChargeElementStdPricebookEntries(conn, productList);
+
+        Util.removeIdFields(priceBooks);
 
         if(priceBooks){
         priceBooks.forEach(priceBook => {
@@ -339,6 +375,12 @@ export class ProductExporter {
 
         let chargeTiers = await Queries.queryChargeTiers(conn, productList, chargeList);
         this.checkTechIds(chargeTiers);
+
+        Util.removeIdFields([
+            ...charges,
+            ...chargeElements,
+            ...chargeTiers
+        ]);
       
         for(let charge of charges){
 

--- a/src/lib/ProductExporter.ts
+++ b/src/lib/ProductExporter.ts
@@ -27,6 +27,7 @@
 import { Util } from './Util';
 import { Connection } from 'jsforce';
 import { Queries } from './query';
+import { debug } from 'util';
 
 export class ProductExporter {
     private categoryIds:Set<String>;
@@ -50,7 +51,10 @@ export class ProductExporter {
     }
 
     public async all(conn: Connection) {
+        debugger;
+        Util.log('BARTDBG: all method');
         if(this.productList[0] === '*ALL'){
+            debugger;
             this.productList = new Set<string>();
             let productList = await Queries.queryAllProductNames(conn);
             for(let product of productList){
@@ -59,6 +63,7 @@ export class ProductExporter {
         }
         Util.setDir(this.dir);
         await Queries.retrieveQueryJson(this.dir);
+        debugger;
         await this.retrievePriceBooks(conn, this.productList);
         Util.createAllDirs(this.isB2B, this.dir);
 
@@ -251,12 +256,26 @@ export class ProductExporter {
     }
 
     private async retrievePriceBooks(conn: Connection, productList: Set<String>){
+        debugger;
         let priceBooks = await Queries.queryPricebooks(conn);
         let currencies = await Queries.queryPricebookEntryCurrencies(conn, productList);
         let priceBookEntries = await Queries.queryPricebookEntries(conn, productList);
         let stdPriceBookEntries = await Queries.queryStdPricebookEntries(conn, productList);
         let chargeElementPricebookEntries = await Queries.queryChargeElementPricebookEntries(conn, productList);
         let chargeElementStdPricebookEntries = await Queries.queryChargeElementStdPricebookEntries(conn, productList);
+        
+        let objectsMissingTechId = Util.getObjectsMissingTechId([
+            ...chargeElementPricebookEntries,
+            ...chargeElementStdPricebookEntries,
+            ...priceBooks, 
+            ...priceBookEntries, 
+            ...stdPriceBookEntries
+        ]);
+
+        if(objectsMissingTechId.length !== 0){
+            
+        }
+
         if(priceBooks){
         priceBooks.forEach(priceBook => {
 

--- a/src/lib/Util.ts
+++ b/src/lib/Util.ts
@@ -3,10 +3,15 @@
 import { core, UX } from "@salesforce/command";
 import * as fs from 'fs';
 import * as fsExtra from 'fs-extra'
+import { SObject } from "jsforce";
 
 export class Util {
 
     private static dir;
+
+    public static getObjectsMissingTechId(objectArray: any){
+        return objectArray.filter(object => !object.enxCPQ__TECH_External_Id__c);
+    }
 
     public static setDir(dir: string){
         this.dir = dir;

--- a/src/lib/Util.ts
+++ b/src/lib/Util.ts
@@ -11,9 +11,23 @@ export class Util {
     private static dir: string;
 
     public static getObjectsMissingTechId(objectArray: Array<any>): Array<any>{
-        return objectArray.filter(object => (
-            !(object.enxCPQ__TECH_External_Id__c || object.enxB2B__TECH_External_Id__c || object.enxB2B__TECH_External_ID__c)
-        ));
+        return objectArray 
+            ? objectArray.filter(object => (
+                !(object.enxCPQ__TECH_External_Id__c || object.enxB2B__TECH_External_Id__c || object.enxB2B__TECH_External_ID__c)
+            ))
+            : [];
+    }
+
+    public static removeIdFields(objectArray: Array<any>): void{
+        if(!objectArray){
+            return;
+        }
+        
+        objectArray.forEach(object => {
+            if(Object.keys(object).includes('Id')){
+                delete object.Id;
+            }
+        });
     }
 
     public static setDir(dir: string){

--- a/src/lib/Util.ts
+++ b/src/lib/Util.ts
@@ -3,11 +3,12 @@
 import { core, UX } from "@salesforce/command";
 import * as fs from 'fs';
 import * as fsExtra from 'fs-extra'
-import { SObject } from "jsforce";
 
 export class Util {
 
-    private static dir;
+    public static OBJECT_MISSING_TECH_ID_ERROR: string = 'Object is missing enxCPQ__TECH_External_Id__c';
+    
+    private static dir: string;
 
     public static getObjectsMissingTechId(objectArray: any){
         return objectArray.filter(object => !object.enxCPQ__TECH_External_Id__c);

--- a/src/lib/Util.ts
+++ b/src/lib/Util.ts
@@ -6,12 +6,14 @@ import * as fsExtra from 'fs-extra'
 
 export class Util {
 
-    public static OBJECT_MISSING_TECH_ID_ERROR: string = 'Object is missing enxCPQ__TECH_External_Id__c';
+    public static OBJECT_MISSING_TECH_ID_ERROR: string = 'Object is missing TECH_External_Id__c field value';
     
     private static dir: string;
 
     public static getObjectsMissingTechId(objectArray: any){
-        return objectArray.filter(object => !object.enxCPQ__TECH_External_Id__c);
+        return objectArray.filter(object => (
+            !(object.enxCPQ__TECH_External_Id__c || object.enxB2B__TECH_External_Id__c || object.enxB2B__TECH_External_ID__c)
+        ));
     }
 
     public static setDir(dir: string){

--- a/src/lib/Util.ts
+++ b/src/lib/Util.ts
@@ -10,7 +10,7 @@ export class Util {
     
     private static dir: string;
 
-    public static getObjectsMissingTechId(objectArray: any){
+    public static getObjectsMissingTechId(objectArray: Array<any>): Array<any>{
         return objectArray.filter(object => (
             !(object.enxCPQ__TECH_External_Id__c || object.enxB2B__TECH_External_Id__c || object.enxB2B__TECH_External_ID__c)
         ));

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -210,7 +210,7 @@ public static async bulkQueryStdPricebookEntries(conn: Connection, productList: 
             });
     })
 }
-//here
+
 public static async queryPricebookEntryCurrencies(conn: Connection, productList: Set<String>): Promise<String[]> {
     Util.log('--- exporting  pricebook entry currencies');
     return new Promise<String[]>((resolve: Function, reject: Function) => {
@@ -346,7 +346,7 @@ public static async bulkQueryPricebookEntries(conn: Connection, productList: Set
 public static async queryProduct(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.log('--- exporting product');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-            conn.query("SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE Name IN (" + Util.setToIdString(productList) + ")", 
+            conn.query("SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE Name IN (" + Util.setToIdString(productList) + ")", 
             null,
             function (err, res) {
                 if (err) {reject('Failed to retrieve product: ' + productList + '. Error: ' + err)};
@@ -372,7 +372,7 @@ public static async queryProduct(conn: Connection, productList: Set<String>): Pr
 
 public static async bulkQueryProduct(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting product');
-        let query = "SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE Name IN (" + Util.setToIdString(productList) + ")";
+        let query = "SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE Name IN (" + Util.setToIdString(productList) + ")";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -395,7 +395,7 @@ public static async bulkQueryProduct(conn: Connection, productList: Set<String>)
 public static async queryProductAttributes(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.log('--- exporting product attributes ');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-            conn.query("SELECT  enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Value_Attribute__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, " + this.productAttrQuery + " FROM enxCPQ__ProductAttribute__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c", 
+            conn.query("SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Value_Attribute__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, " + this.productAttrQuery + " FROM enxCPQ__ProductAttribute__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve product attributes:  Error: ' + err);
@@ -419,7 +419,7 @@ public static async queryProductAttributes(conn: Connection, productList: Set<St
 
 public static async bulkQueryProductAttributes(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting product attributes');
-        let query = "SELECT  enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Value_Attribute__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c" + this.productAttrQuery + " FROM enxCPQ__ProductAttribute__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c";
+        let query = "SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Value_Attribute__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c" + this.productAttrQuery + " FROM enxCPQ__ProductAttribute__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -440,7 +440,7 @@ public static async bulkQueryProductAttributes(conn: Connection, productList: Se
 public static async queryProductOptions(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.log('--- exporting product options ');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-            conn.query("SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+ " FROM Product2 WHERE RecordType.Name = 'Option' AND enxCPQ__Parent_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Sorting_Order__c", 
+            conn.query("SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+ " FROM Product2 WHERE RecordType.Name = 'Option' AND enxCPQ__Parent_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Sorting_Order__c", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve options. Error: ' + err);
@@ -464,7 +464,7 @@ public static async queryProductOptions(conn: Connection, productList: Set<Strin
 
 public static async bulkQueryProductOptions(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting product options');
-        let query = "SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+ "FROM Product2 WHERE RecordType.Name = 'Option' AND enxCPQ__Parent_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Sorting_Order__c";
+        let query = "SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+ "FROM Product2 WHERE RecordType.Name = 'Option' AND enxCPQ__Parent_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Sorting_Order__c";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -759,7 +759,7 @@ public static async queryProductAttributeValues(conn: Connection, productList: S
        Util.log('--- exporting product attribute values ');
        return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-           conn.query("SELECT enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery +" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = false AND enxCPQ__Exclusive_for_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c", 
+           conn.query("SELECT Id, enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery +" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = false AND enxCPQ__Exclusive_for_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c", 
            null,
            function (err, res) {
             if (err) reject('Failed to retrieve product attribute values. Error: ' + err);
@@ -783,7 +783,7 @@ public static async queryProductAttributeValues(conn: Connection, productList: S
 
 public static async bulkQueryProductAttributeValues(conn: Connection, productList: Set<String>): Promise<String[]> {
     Util.showSpinner('---bulk exporting product attribute values');
-    let query = "SELECT enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery +" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = false AND enxCPQ__Exclusive_for_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c";
+    let query = "SELECT Id, enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery +" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = false AND enxCPQ__Exclusive_for_Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c";
     return new  Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -805,7 +805,7 @@ public static async queryAttributeDefaultValues(conn: Connection, productList: S
     Util.log('--- exporting attribute default values ');
     return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-        conn.query("SELECT enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrDefaultValuesQuery +" FROM enxCPQ__AttributeDefaultValue__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c", 
+        conn.query("SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrDefaultValuesQuery +" FROM enxCPQ__AttributeDefaultValue__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c", 
         null,
         function (err, res) {
             if (err) reject('Failed to retrieve attribute default values. Error: ' + err);
@@ -829,7 +829,7 @@ public static async queryAttributeDefaultValues(conn: Connection, productList: S
 
 public static async bulkQueryAttributeDefaultValues(conn: Connection, productList: Set<String>): Promise<String[]> {
     Util.showSpinner('---bulk exporting attribute default values');
-    let query = "SELECT enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrDefaultValuesQuery +" FROM enxCPQ__AttributeDefaultValue__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c";
+    let query = "SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrDefaultValuesQuery +" FROM enxCPQ__AttributeDefaultValue__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c";
     return new  Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -851,7 +851,7 @@ public static async queryProductRelationships(conn: Connection, productList: Set
     Util.log('--- exporting product relationships ');
     return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-        conn.query("SELECT enxCPQ__Primary_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Secondary_Product__r.enxCPQ__TECH_External_Id__c, "+ this.productRelationshipsQuery+" FROM enxCPQ__ProductRelationship__c WHERE enxCPQ__Primary_Product__r.Name IN (" + Util.setToIdString(productList) + ") AND enxCPQ__Secondary_Product__c != null", 
+        conn.query("SELECT Id, enxCPQ__Primary_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Secondary_Product__r.enxCPQ__TECH_External_Id__c, "+ this.productRelationshipsQuery+" FROM enxCPQ__ProductRelationship__c WHERE enxCPQ__Primary_Product__r.Name IN (" + Util.setToIdString(productList) + ") AND enxCPQ__Secondary_Product__c != null", 
         null,
         function (err, res) {
             if (err) reject('Failed to retrieve product relationships. Error: ' + err);
@@ -875,7 +875,7 @@ public static async queryProductRelationships(conn: Connection, productList: Set
 
 public static async bulkQueryProductRelationships(conn: Connection, productList: Set<String>): Promise<String[]> {
     Util.showSpinner('---bulk exporting product relationships');
-    let query = "SELECT enxCPQ__Primary_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Secondary_Product__r.enxCPQ__TECH_External_Id__c, "+ this.productRelationshipsQuery+" FROM enxCPQ__ProductRelationship__c WHERE enxCPQ__Primary_Product__r.Name IN (" + Util.setToIdString(productList) + ") AND enxCPQ__Secondary_Product__c != null";
+    let query = "SELECT Id, enxCPQ__Primary_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Secondary_Product__r.enxCPQ__TECH_External_Id__c, "+ this.productRelationshipsQuery+" FROM enxCPQ__ProductRelationship__c WHERE enxCPQ__Primary_Product__r.Name IN (" + Util.setToIdString(productList) + ") AND enxCPQ__Secondary_Product__c != null";
     return new  Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -897,7 +897,7 @@ public static async queryAttributeValueDependencies(conn: Connection, productLis
     Util.log('--- exporting attribute value dependency ');
     return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-        conn.query("SELECT enxCPQ__Dependent_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Dependent_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrValueDependecyQuery +" FROM enxCPQ__AttributeValueDependency__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c", 
+        conn.query("SELECT Id, enxCPQ__Dependent_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Dependent_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrValueDependecyQuery +" FROM enxCPQ__AttributeValueDependency__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c", 
         null,
         function (err, res) {
             if (err) reject('Failed to retrieve attribute value dependency. Error: ' + err);
@@ -921,7 +921,7 @@ public static async queryAttributeValueDependencies(conn: Connection, productLis
 
 public static async bulkQueryAttributeValueDependencies(conn: Connection, productList: Set<String>): Promise<String[]> {
     Util.showSpinner('---bulk exporting attribute value dependency');
-    let query = "SELECT enxCPQ__Dependent_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Dependent_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrValueDependecyQuery +" FROM enxCPQ__AttributeValueDependency__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c";
+    let query = "SELECT Id, enxCPQ__Dependent_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Dependent_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Value__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c,  enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Master_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrValueDependecyQuery +" FROM enxCPQ__AttributeValueDependency__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__TECH_External_Id__c";
     return new  Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -942,7 +942,7 @@ public static async queryAttributeRules(conn: Connection, productList: Set<Strin
         Util.log('--- exporting attribute rules ');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-            conn.query("SELECT enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrRulesQuery +" FROM enxCPQ__AttributeRule__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c", 
+            conn.query("SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrRulesQuery +" FROM enxCPQ__AttributeRule__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve attribute rules. Error: ' + err);
@@ -966,7 +966,7 @@ public static async queryAttributeRules(conn: Connection, productList: Set<Strin
 
 public static async bulkQueryAttributeRules(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting attribute rules');
-        let query = "SELECT enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrRulesQuery +" FROM enxCPQ__AttributeRule__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c";
+        let query = "SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Product__r.enxCPQ__TECH_External_Id__c, RecordType.Name, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, "+ this.attrRulesQuery +" FROM enxCPQ__AttributeRule__c WHERE enxCPQ__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxCPQ__Order__c";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -988,7 +988,7 @@ public static async queryProvisioningPlanAssigns(conn: Connection, productList: 
         Util.log('--- exporting provisioning plan assignments');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-            conn.query("SELECT  enxB2B__Product__r.enxCPQ__TECH_External_Id__c, enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, "+ this.prvPlanAssignmentQuery +" FROM enxB2B__ProvisioningPlanAssignment__c WHERE enxB2B__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxB2B__Order__c", 
+            conn.query("SELECT Id, enxB2B__Product__r.enxCPQ__TECH_External_Id__c, enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, "+ this.prvPlanAssignmentQuery +" FROM enxB2B__ProvisioningPlanAssignment__c WHERE enxB2B__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxB2B__Order__c", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve provisioning plan assignments Error: ' + err);
@@ -1012,7 +1012,7 @@ public static async queryProvisioningPlanAssigns(conn: Connection, productList: 
 
 public static async bulkQueryProvisioningPlanAssigns(conn: Connection, productList: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting provisioning plan assignments');
-        let query = "SELECT  enxB2B__Product__r.enxCPQ__TECH_External_Id__c, enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, "+ this.prvPlanAssignmentQuery +" FROM enxB2B__ProvisioningPlanAssignment__c WHERE enxB2B__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxB2B__Order__c";
+        let query = "SELECT Id, enxB2B__Product__r.enxCPQ__TECH_External_Id__c, enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, "+ this.prvPlanAssignmentQuery +" FROM enxB2B__ProvisioningPlanAssignment__c WHERE enxB2B__Product__r.Name IN (" + Util.setToIdString(productList) + ") ORDER BY enxB2B__Order__c";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -258,7 +258,7 @@ public static async bulkQueryPricebookEntryCurrencies(conn: Connection, productL
 public static async queryPricebooks(conn: Connection): Promise<String[]> {
         Util.log('--- exporting pricebooks');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-        conn.query("SELECT IsStandard, "+ this.pricebookQuery+" FROM Pricebook2 WHERE IsActive = true OR IsStandard = true", 
+        conn.query("SELECT Id, IsStandard, "+ this.pricebookQuery+" FROM Pricebook2 WHERE IsActive = true OR IsStandard = true", 
         null,
         function (err, res) {
             if (err) reject('error retrieving pricebooks: ' + err);

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -485,11 +485,12 @@ public static async bulkQueryProductOptions(conn: Connection, productList: Set<S
 public static async queryAttributeSetAttributes(conn: Connection, attributeSetIds: Set<String>): Promise<String[]> {
         Util.log('--- exporting attributes set attributes ');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-            conn.query("SELECT enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, "+ this.attrSetAttrQuery +" FROM enxCPQ__AttributeSetAttribute__c ORDER BY enxCPQ__Order__c ", 
+            conn.query("SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, "+ this.attrSetAttrQuery +
+                " FROM enxCPQ__AttributeSetAttribute__c WHERE enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeSetIds) + ") ORDER BY enxCPQ__Order__c", 
+
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve attribute set attributes. Error: ' + err);
-                if( attributeSetIds.size === 0) resolve([""]);
                 if (res.records.length < 200){
                     Util.log("--- attribute set attributes: " + res.records.length);
                     resolve(res.records);
@@ -501,7 +502,7 @@ public static async queryAttributeSetAttributes(conn: Connection, attributeSetId
 
         }).then(async result =>{
             if(result[0] === 'useBulkApi'){
-                return await this.bulkQueryAttributeSetAttributes(conn);
+                return await this.bulkQueryAttributeSetAttributes(conn, attributeSetIds);
             }else{
                 return result;
             }
@@ -509,9 +510,10 @@ public static async queryAttributeSetAttributes(conn: Connection, attributeSetId
   );
     }
 
-public static async bulkQueryAttributeSetAttributes(conn: Connection): Promise<String[]> {
+public static async bulkQueryAttributeSetAttributes(conn: Connection, attributeSetIds: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting attributes set attributes');
-        let query = "SELECT enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, "+ this.attrSetAttrQuery +" FROM enxCPQ__AttributeSetAttribute__c ORDER BY enxCPQ__Order__c ";
+        let query = "SELECT Id, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c, "+ this.attrSetAttrQuery +
+            " FROM enxCPQ__AttributeSetAttribute__c WHERE enxCPQ__Attribute_Set__r.enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeSetIds) + ") ORDER BY enxCPQ__Order__c";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -536,7 +538,7 @@ public static async queryAttributes(conn: Connection, attributeIds: Set<String>)
         }
         return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-            conn.query("SELECT "+ this.attrQuery +" FROM enxCPQ__Attribute__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ", 
+            conn.query("SELECT Id, "+ this.attrQuery +" FROM enxCPQ__Attribute__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve attributes. Error: ' + err);
@@ -560,7 +562,7 @@ public static async queryAttributes(conn: Connection, attributeIds: Set<String>)
 
 public static async bulkQueryAttributes(conn: Connection, attributeIds: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting attributes');
-        let query = "SELECT "+ this.attrQuery +" FROM enxCPQ__Attribute__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ";
+        let query = "SELECT Id, "+ this.attrQuery +" FROM enxCPQ__Attribute__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -582,7 +584,7 @@ public static async queryProvisioningTasks(conn: Connection): Promise<String[]> 
         Util.log('--- exporting provisioning tasks ');
 
     return new Promise<String[]>((resolve: Function, reject: Function) => {
-        conn.query("SELECT "+ this.prvTaskQuery+" FROM enxB2B__ProvisioningTask__c",null, function(err, res) {
+        conn.query("SELECT Id, "+ this.prvTaskQuery+" FROM enxB2B__ProvisioningTask__c",null, function(err, res) {
             if (err) reject('error retrieving provisioning tasks: ' + err);
             if(res.records.length<200){
                 Util.log('---provisioning tasks: ' + res.records.length);
@@ -604,7 +606,7 @@ public static async queryProvisioningTasks(conn: Connection): Promise<String[]> 
 
 public static async bulkQueryProvisioningTasks(conn: Connection): Promise<String[]> {
     Util.showSpinner('--- bulk exporting provisioning tasks');
-    let query = "SELECT "+ this.prvTaskQuery+" FROM enxB2B__ProvisioningTask__c";
+    let query = "SELECT Id "+ this.prvTaskQuery+" FROM enxB2B__ProvisioningTask__c";
     return new Promise<string[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -625,7 +627,7 @@ public static async bulkQueryProvisioningTasks(conn: Connection): Promise<String
 public static async queryProvisioningPlans(conn: Connection): Promise<String[]> {
         Util.log('--- exporting provisioning plans');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-        conn.query("SELECT "+ this.prvPlanQuery+" FROM enxB2B__ProvisioningPlan__c", null, function(err, res) {
+        conn.query("SELECT Id, "+ this.prvPlanQuery+" FROM enxB2B__ProvisioningPlan__c", null, function(err, res) {
             if (err) reject('error retrieving provisioning plans: ' + err);
             if (res.records.length < 200){
                 Util.log("--- provisioning plans: " + res.records.length);
@@ -647,7 +649,7 @@ public static async queryProvisioningPlans(conn: Connection): Promise<String[]> 
 
 public static async bulkQueryProvisioningPlans(conn: Connection): Promise<String[]> {
     Util.showSpinner('--- bulk exporting provisioning plans');
-    let query = "SELECT "+ this.prvPlanQuery+" FROM enxB2B__ProvisioningPlan__c";
+    let query = "SELECT Id, "+ this.prvPlanQuery+" FROM enxB2B__ProvisioningPlan__c";
     return new  Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -667,7 +669,7 @@ public static async bulkQueryProvisioningPlans(conn: Connection): Promise<String
 public static async  queryProductCharges(conn: Connection, productList: Set<String>): Promise<String[]> {
          Util.log('--- exporting product charges ');
          return new Promise<String[]>((resolve: Function, reject: Function) => {
-         conn.query("SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE RecordType.Name = 'Charge' AND (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") OR enxCPQ__Charge_Reference__c !=null)  ORDER BY enxCPQ__Sorting_Order__c", 
+         conn.query("SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE RecordType.Name = 'Charge' AND (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") OR enxCPQ__Charge_Reference__c !=null)  ORDER BY enxCPQ__Sorting_Order__c", 
          null,
          function (err, res) {
             if (err) reject('Failed to retrieve charges error: ' + err);
@@ -692,7 +694,7 @@ public static async  queryProductCharges(conn: Connection, productList: Set<Stri
 
 public static async  bulkQueryProductCharges(conn: Connection, productList: Set<String>): Promise<String[]> {
     Util.showSpinner('--- bulk exporting product charges');
-    let query = "SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE RecordType.Name = 'Charge' AND (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") OR enxCPQ__Charge_Reference__c !=null)  ORDER BY enxCPQ__Sorting_Order__c";
+    let query = "SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE RecordType.Name = 'Charge' AND (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") OR enxCPQ__Charge_Reference__c !=null)  ORDER BY enxCPQ__Sorting_Order__c";
     return new  Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -1037,7 +1039,7 @@ public static async queryCategories(conn: Connection, categoryIds: Set<String>):
         }
         return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-            conn.query("SELECT enxCPQ__Parameter_Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Category__r.enxCPQ__TECH_External_Id__c, " + this.categoryQuery +" FROM enxCPQ__Category__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(categoryIds) + ") ", 
+            conn.query("SELECT Id, enxCPQ__Parameter_Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Category__r.enxCPQ__TECH_External_Id__c, " + this.categoryQuery +" FROM enxCPQ__Category__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(categoryIds) + ") ", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve categories. Error: ' + err);
@@ -1061,7 +1063,7 @@ public static async queryCategories(conn: Connection, categoryIds: Set<String>):
 
 public static async bulkQueryCategories(conn: Connection, categoryIds: Set<String>): Promise<String[]> {
         Util.showSpinner('--- bulk exporting categories');
-        let query = "SELECT enxCPQ__Parameter_Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Category__r.enxCPQ__TECH_External_Id__c, " + this.categoryQuery +" FROM enxCPQ__Category__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(categoryIds) + ") ";
+        let query = "SELECT Id, enxCPQ__Parameter_Attribute_Set__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Category__r.enxCPQ__TECH_External_Id__c, " + this.categoryQuery +" FROM enxCPQ__Category__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(categoryIds) + ") ";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -1086,7 +1088,7 @@ public static async queryAttributeValues(conn: Connection, attributeIds: Set<Str
         }
         return new Promise<String[]>((resolve: Function, reject: Function) => {
 
-            conn.query("SELECT enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery+" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = true AND enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ORDER BY enxCPQ__Order__c", 
+            conn.query("SELECT Id, enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery+" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = true AND enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ORDER BY enxCPQ__Order__c", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve product attribute values: ' + attributeIds + '. Error: ' + err);
@@ -1109,7 +1111,7 @@ public static async queryAttributeValues(conn: Connection, attributeIds: Set<Str
 }
 public static async bulkQueryAttributeValues(conn: Connection, attributeIds: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting product attribute values');
-        let query = "SELECT enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery+" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = true AND enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ORDER BY enxCPQ__Order__c";
+        let query = "SELECT Id, enxCPQ__Exclusive_for_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c, "+ this.attrValuesQuery+" FROM enxCPQ__AttributeValue__c WHERE enxCPQ__Global__c = true AND enxCPQ__Attribute__r.enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeIds) + ") ORDER BY enxCPQ__Order__c";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -1131,11 +1133,10 @@ public static async queryAttributeSets(conn: Connection, attributeSetIds: Set<St
         Util.log('--- exporting attributes sets');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
             
-            conn.query("SELECT "+ this.attrSetQuery+" FROM enxCPQ__AttributeSet__c ", 
+            conn.query("SELECT Id, "+ this.attrSetQuery+" FROM enxCPQ__AttributeSet__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeSetIds) + ") ", 
             null,
             function (err, res) {
                 if (err) reject('Failed to retrieve attribute sets. Error: ' + err);
-                if( attributeSetIds.size === 0) resolve([""]);
                 if (res.records.length < 200){
                     Util.log("--- attributes sets: " + res.records.length);
                     resolve(res.records);
@@ -1147,7 +1148,7 @@ public static async queryAttributeSets(conn: Connection, attributeSetIds: Set<St
 
         }).then(async result =>{
             if(result[0] === 'useBulkApi'){
-                return await this.bulkQueryAttributeSets(conn);
+                return await this.bulkQueryAttributeSets(conn, attributeSetIds);
             }else{
                 return result;
             }
@@ -1155,9 +1156,9 @@ public static async queryAttributeSets(conn: Connection, attributeSetIds: Set<St
    );
 }
 
-public static async bulkQueryAttributeSets(conn: Connection): Promise<String[]> {
+public static async bulkQueryAttributeSets(conn: Connection, attributeSetIds: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting attributes sets');
-        let query = "SELECT "+ this.attrSetQuery+" FROM enxCPQ__AttributeSet__c ";
+        let query = "SELECT Id, "+ this.attrSetQuery+" FROM enxCPQ__AttributeSet__c WHERE enxCPQ__TECH_External_Id__c IN (" + Util.setToIdString(attributeSetIds) + ") ";
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -1203,7 +1204,7 @@ public static async queryProvisioningTaskAssignmentIds (conn: Connection): Promi
 public static async queryProvisioningTaskAssignments (conn: Connection): Promise<String[]> {
         Util.log('--- exporting Provisioning task assignments');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-        conn.query("SELECT enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, enxB2B__Provisioning_Task__r.enxB2B__TECH_External_Id__c, "+ this.prvTaskAssignmentQuery +" FROM enxB2B__ProvisioningTaskAssignment__c",
+        conn.query("SELECT Id, enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, enxB2B__Provisioning_Task__r.enxB2B__TECH_External_Id__c, "+ this.prvTaskAssignmentQuery +" FROM enxB2B__ProvisioningTaskAssignment__c",
         null,
         function(err, res) {
             if (err) reject('error retrieving provisioning task assignments: ' + err);
@@ -1227,7 +1228,7 @@ public static async queryProvisioningTaskAssignments (conn: Connection): Promise
 
 public static async bulkQueryProvisioningTaskAssignments (conn: Connection): Promise<String[]> {
         Util.showSpinner('---bulk exporting Provisioning task assignments');
-        let query = "SELECT enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, enxB2B__Provisioning_Task__r.enxB2B__TECH_External_Id__c, "+ this.prvTaskAssignmentQuery +" FROM enxB2B__ProvisioningTaskAssignment__c"
+        let query = "SELECT Id, enxB2B__Provisioning_Plan__r.enxB2B__TECH_External_Id__c, enxB2B__Provisioning_Task__r.enxB2B__TECH_External_Id__c, "+ this.prvTaskAssignmentQuery +" FROM enxB2B__ProvisioningTaskAssignment__c"
         return new  Promise<String[]>((resolve: Function, reject: Function) => {
             var records = []; 
             conn.bulk.query(query)
@@ -1376,7 +1377,7 @@ public static async bulkQueryChargeElementPricebookEntries (conn: Connection, pr
 public static async queryChargeElements (conn: Connection, productList: Set<String>, chargeList: Set<String>): Promise<String[]> {
         Util.showSpinner('--- exporting charge elements ');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-            conn.query("SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Element'",
+            conn.query("SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Element'",
             null,
             function(err, res) {
                 if (err) reject('error retrieving charge elements: ' + err);
@@ -1400,7 +1401,7 @@ public static async queryChargeElements (conn: Connection, productList: Set<Stri
 }
 public static async bulkQueryChargeElements (conn: Connection, productList: Set<String>, chargeList: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting charge elements');
-        let query = "SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Element'";
+        let query = "SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Element'";
         return new Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)
@@ -1421,7 +1422,7 @@ public static async bulkQueryChargeElements (conn: Connection, productList: Set<
 public static async queryChargeTiers (conn: Connection,  productList: Set<String>, chargeList: Set<String>): Promise<String[]> {
         Util.log('--- exporting charge Tiers ');
         return new Promise<String[]>((resolve: Function, reject: Function) => {
-            conn.query("SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Tier'",
+            conn.query("SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Tier'",
             null,
             function(err, res) {
                 if (err) reject('error retrieving charge Tiers: ' + err);
@@ -1445,7 +1446,7 @@ public static async queryChargeTiers (conn: Connection,  productList: Set<String
 
 public static async bulkQueryChargeTiers (conn: Connection,  productList: Set<String>, chargeList: Set<String>): Promise<String[]> {
         Util.showSpinner('---bulk exporting charge Tiers');
-        let query = "SELECT enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Tier'";
+        let query = "SELECT Id, enxCPQ__Category__r.enxCPQ__TECH_External_Id__c, enxCPQ__Multiplier_Attribute__r.enxCPQ__TECH_External_Id__c, enxCPQ__Parent_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Root_Product__r.enxCPQ__TECH_External_Id__c, enxCPQ__Charge_Parent__r.enxCPQ__TECH_External_Id__c, RecordType.Name, "+this.productQuery+" FROM Product2 WHERE (enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(productList) + ") or enxCPQ__Root_Product__r.Name IN (" + Util.setToIdString(chargeList) + ")) AND RecordType.Name = 'Charge Tier'";
         return new Promise<String[]>((resolve: Function, reject: Function) => {
         var records = []; 
         conn.bulk.query(query)


### PR DESCRIPTION
Calls to checkTechIds method in ProductExporter class could be minimalized by checking tech ids for many lists at once, but I stated that It would be more user-friendly to show eventual error after specific object export.